### PR TITLE
fix: made font detection more reliable

### DIFF
--- a/src/dom-to-image-improved.js
+++ b/src/dom-to-image-improved.js
@@ -764,7 +764,7 @@
             function getCssRules(styleSheets) {
                 var cssRules = [];
                 styleSheets.forEach(function(sheet) {
-                    if (sheet.hasOwnProperty("cssRules")) {
+                    if (Object.getPrototypeOf(sheet).hasOwnProperty("cssRules")) {
                         try {
                             util.asArray(sheet.cssRules || []).forEach(cssRules.push.bind(cssRules));
                         } catch (e) {


### PR DESCRIPTION
Use Object.getPrototypeOf(sheet).hasOwnProperty(cssRules)

This fix was taken from https://github.com/1904labs/dom-to-image-more

Root issue:
https://github.com/1904labs/dom-to-image-more/issues/21